### PR TITLE
Fix render-blocking CSS and layout shift issues

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -117,14 +117,14 @@ eleventyConfig.addCollection("redirects", function(collectionApi) {
     </div>`;
   });
 
-  // keep original plugin for backwards compatibility
-  eleventyConfig.addPlugin(embedYouTube, {
-  lazy: true,
-  modestBranding: true,
-  noCookie: true,
-  embedClass: "youtube-embed",
-  lite: true,
-});
+  // Disabled YouTube plugin to avoid JSDelivr CDN blocking - use {% youtube %} shortcode instead
+  // eleventyConfig.addPlugin(embedYouTube, {
+  //   lazy: true,
+  //   modestBranding: true,
+  //   noCookie: true,
+  //   embedClass: "youtube-embed",
+  //   lite: true,
+  // });
   // Google Slides shortcode
   eleventyConfig.addShortcode("googleSlides", function(id, width = 960, height = 569, title = "Embedded Google Slides Presentation") {
   return `<div class="slideshow-container">

--- a/src/_includes/_head.html
+++ b/src/_includes/_head.html
@@ -422,12 +422,56 @@
             }
         }
 
+        /* Critical YouTube Lite styles to prevent CLS */
+        .youtube-lite {
+            position: relative;
+            display: block;
+            width: 100%;
+            padding-bottom: 56.25%;
+            background-color: #000;
+            cursor: pointer;
+            overflow: hidden;
+        }
+
+        .youtube-lite img {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            border: 0;
+        }
+
+        /* Critical layout styles to prevent CLS */
+        body {
+            margin: 0;
+            padding: 0.5rem;
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        @media (min-width: 900px) {
+            body {
+                display: grid;
+                grid-template-columns: 2fr 1fr;
+                grid-template-areas:
+                    "header header"
+                    "nav nav"
+                    "main aside"
+                    "footer footer";
+                gap: var(--spacing-md);
+                padding: 1rem;
+            }
+        }
+
     </style>
 
     <link rel="preload" href="/style.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="/style.css"></noscript>
 
-    <link rel="stylesheet" href="/youtube-lite.css">
+    <link rel="preload" href="/youtube-lite.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="/youtube-lite.css"></noscript>
     <script src="/youtube-lite.js" defer></script>
 
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64' width='64' height='64'%3E%3Cpath d='M18 16 L18 48 L24 48 L24 36 L36 36 C42 36 46 32 46 26 C46 20 42 16 36 16 L18 16 Z M24 22 L34 22 C36 22 38 24 38 26 C38 28 36 30 34 30 L24 30 L24 22 Z' fill='%2347682C' stroke='white' stroke-width='1'/%3E%3Ccircle cx='48' cy='20' r='3' fill='%23AE0A2B' stroke='white' stroke-width='0.5'/%3E%3C/svg%3E">


### PR DESCRIPTION
- Made youtube-lite.css load asynchronously to eliminate 210ms blocking
- Disabled YouTube plugin to remove JSDelivr CDN blocking (200ms)
- Inlined critical YouTube and layout CSS to prevent CLS (was 1.000)
- Added body grid layout to inline styles to prevent layout shift

Note: YouTube URLs in markdown will no longer auto-embed. Use {% youtube "videoId" "title" %} shortcode instead.