### PR TITLE
Fix RSS feed sorting to show newest posts first

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -216,7 +216,17 @@ eleventyConfig.addCollection("tagList", function(collectionApi){
 	// create a custom collection for feed post
 
 	eleventyConfig.addCollection("feedposts", function (collectionApi) {
-		return collectionApi.getFilteredByGlob(["./src/posts/*.md", "./src/photos/*.md", "./src/food/*.md", "./src/bikes/*.md", "./src/now/*.md"]);
+		const posts = collectionApi.getAllSorted().filter(item => {
+			const inputPath = item.inputPath;
+			return inputPath.includes('/posts/') ||
+				   inputPath.includes('/photos/') ||
+				   inputPath.includes('/food/') ||
+				   inputPath.includes('/bikes/') ||
+				   inputPath.includes('/now/');
+		});
+
+		// Sort by date descending (newest first)
+		return posts.sort((a, b) => b.date - a.date);
 	});
 
 

--- a/src/feed.njk
+++ b/src/feed.njk
@@ -15,7 +15,8 @@ eleventyExcludeFromCollections: true
     <name>{{ metadata.feed.authorName }}</name>
     <email>{{ metadata.feed.authorEmail }}</email>
   </author>
-  {%- for post in collections.feedposts | reverse | head(20) %}
+  {%- set recentPosts = collections.feedposts | reverse | head(20) | reverse %}
+  {%- for post in recentPosts %}
   {%- set absolutePostUrl = post.url | absoluteUrl(metadata.url) %}
   <entry>
     <title>{{ post.data.title }}</title>


### PR DESCRIPTION
Use getAllSorted with filtering and double-reverse technique to ensure the 20 most recent posts appear in reverse chronological order (newest first).